### PR TITLE
Added "stat" to list of commands to check for.

### DIFF
--- a/par2drive
+++ b/par2drive
@@ -17,7 +17,7 @@ files_that_failed=""
 
 #checking that all commands are available
 
-for i in grep find rm par2 printf ; do
+for i in grep find rm par2 printf stat ; do
 
 which $i > /dev/null
 	if [ "$?" != "0" ] ; then


### PR DESCRIPTION
par2drive runs fine on OpenWRT except that stat must first be manually installed, as it is not installed by default. Fortunately stat is available in the entware package coreutils-stat.